### PR TITLE
Support 6.0

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,5 +1,5 @@
 /* load the default Redmine stylesheet */
-@import url(../../application.css);
+@import url(../../../stylesheets/application.css);
 
 /* theme_darkcolor */
 #header {

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,5 +1,5 @@
 /* load the default Redmine stylesheet */
-@import url(../../../stylesheets/application.css);
+@import url(../../application.css);
 
 /* theme_darkcolor */
 #header {

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -3,7 +3,7 @@
 
 /* theme_darkcolor */
 #header {
-     background-color: #202030;
+     background: #202030;
 }
 #top-menu{
   background: #333445;

--- a/stylesheets/responsive.css
+++ b/stylesheets/responsive.css
@@ -15,4 +15,12 @@
   border-top: none;
   border-bottom: none;
 }
+.flyout-menu #admin-menu a,
+.flyout-menu #admin-menu a.selected {
+  padding-left: 0 !important;
+}
+.flyout-menu #admin-menu a svg.icon-svg ,
+.flyout-menu #admin-menu a.selected svg.icon-svg {
+  stroke: #FFF;
+}
 }

--- a/stylesheets/responsive.css
+++ b/stylesheets/responsive.css
@@ -1,5 +1,5 @@
 /* load the default Redmine stylesheet */
-@import url(../../../stylesheets/responsive.css);
+@import url(../../responsive.css);
 
 /* theme_darkcolor */
 @media screen and (max-width: 899px)

--- a/stylesheets/responsive.css
+++ b/stylesheets/responsive.css
@@ -1,5 +1,5 @@
 /* load the default Redmine stylesheet */
-@import url(../../responsive.css);
+@import url(../../../stylesheets/responsive.css);
 
 /* theme_darkcolor */
 @media screen and (max-width: 899px)

--- a/stylesheets/responsive.css
+++ b/stylesheets/responsive.css
@@ -15,10 +15,20 @@
   border-top: none;
   border-bottom: none;
 }
-.flyout-menu #admin-menu a,
-.flyout-menu #admin-menu a.selected {
+
+#admin-index #admin-menu a:has(svg) {
+  padding-left: 6px !important;
+}
+
+#admin-index #admin-menu a svg.icon-svg + .icon-label {
+  margin-left: 8px;
+}
+
+.flyout-menu #admin-menu a:has(svg),
+.flyout-menu #admin-menu a.selected:has(svg) {
   padding-left: 0 !important;
 }
+
 .flyout-menu #admin-menu a svg.icon-svg ,
 .flyout-menu #admin-menu a.selected svg.icon-svg {
   stroke: #FFF;


### PR DESCRIPTION
- 標準cssへのパスを変更
- ヘッダーのグラデーション化によるcssの指定方法の変更により、Lycheeのスタイルの優先度が下がって背景色が適用されていなかったので対応
- モバイルメニューで管理系のメニューに不自然な余白が発生していたため調整